### PR TITLE
Terminate ec2 runner when github runner registered failed

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -59,18 +59,22 @@ async function startEc2Instance(label, githubRegistrationToken) {
 }
 
 async function terminateEc2Instance() {
+  await terminateEc2InstanceById(config.input.ec2InstanceId);
+}
+
+async function terminateEc2InstanceById(ec2InstanceId) {
   const ec2 = new AWS.EC2();
 
   const params = {
-    InstanceIds: [config.input.ec2InstanceId],
+    InstanceIds: [ec2InstanceId],
   };
 
   try {
     await ec2.terminateInstances(params).promise();
-    core.info(`AWS EC2 instance ${config.input.ec2InstanceId} is terminated`);
+    core.info(`AWS EC2 instance ${ec2InstanceId} is terminated`);
     return;
   } catch (error) {
-    core.error(`AWS EC2 instance ${config.input.ec2InstanceId} termination error`);
+    core.error(`AWS EC2 instance ${ec2InstanceId} termination error`);
     throw error;
   }
 }
@@ -95,5 +99,6 @@ async function waitForInstanceRunning(ec2InstanceId) {
 module.exports = {
   startEc2Instance,
   terminateEc2Instance,
+  terminateEc2InstanceById,
   waitForInstanceRunning,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,15 @@ async function start() {
   const githubRegistrationToken = await gh.getRegistrationToken();
   const ec2InstanceId = await aws.startEc2Instance(label, githubRegistrationToken);
   setOutput(label, ec2InstanceId);
-  await aws.waitForInstanceRunning(ec2InstanceId);
-  await gh.waitForRunnerRegistered(label);
+
+  try {
+    await aws.waitForInstanceRunning(ec2InstanceId);
+    await gh.waitForRunnerRegistered(label);
+  }
+  catch (error) {
+    await aws.terminateEc2InstanceById(ec2InstanceId);
+    throw error;
+  }
 }
 
 async function stop() {


### PR DESCRIPTION
proof that this works
https://github.com/Canner/presto/runs/4443164081?check_suite_focus=true
<img width="739" alt="截圖 2021-12-07 下午7 47 36" src="https://user-images.githubusercontent.com/4344302/145023927-0b86f305-1706-4be1-b10c-47c1e84e4191.png">

As you can see if error raise in `start()` we'll terminate the ec2 instance.

My test is based on https://github.com/brandboat/ec2-github-runner/tree/bugfix/test-remove-ec2-when-error-happen

Since it is hard to reproduce the bug, the link above is based on this pr and do https://github.com/brandboat/ec2-github-runner/commit/b476217546ca63c5b1e9fa39f467a09d1951af63